### PR TITLE
Fixed a bug that crashed fabricio at credentials overwrite

### DIFF
--- a/lib/fabricio/cli.rb
+++ b/lib/fabricio/cli.rb
@@ -81,7 +81,7 @@ module Fabricio
     end
 
     def create_credential_file(credential)
-      FileUtils.mkdir(CREDENTIAL_DIRECTORY_PATH)
+      FileUtils.mkdir_p(CREDENTIAL_DIRECTORY_PATH)
       credential_hash = {
         "email" => credential.email,
         "password" => credential.password


### PR DESCRIPTION
Calling `fabricio credential` crashed fabricio if there already were saved credentials.