### PR TITLE
Fix 'uninitialized constant Fabricio::Model::Point::DateTime (NameError)'

### DIFF
--- a/lib/fabricio/models/point.rb
+++ b/lib/fabricio/models/point.rb
@@ -1,3 +1,5 @@
+require 'date'
+
 module Fabricio
   module Model
     # This model represents a data point with two fields - timestamp and value


### PR DESCRIPTION
Ruby version: 2.4.1
