### PR TITLE
Adding API for time spent in app per user

### DIFF
--- a/lib/fabricio/networking/app_request_model_factory.rb
+++ b/lib/fabricio/networking/app_request_model_factory.rb
@@ -162,6 +162,30 @@ module Fabricio
         model
       end
 
+      # Returns a request model for obtaining the time in app per user
+      #
+      # @param session [Fabricio::Authorization::Session]
+      # @param app_id [String]
+      # @param start_time [String] Timestamp of the start date
+      # @param end_time [String] Timestamp of the end date
+      # @param build [String] The version of the build. E.g. '4.0.1 (38)'
+      # @return [Fabricio::Networking::RequestModel]
+      def time_in_app_per_user_request_model(session, app_id, start_time, end_time, build)
+        path = growth_analytics_endpoint(session, app_id, 'time_in_app_per_dau')
+        params = {
+            'start' => start_time,
+            'end' => end_time,
+            'build' => build
+        }
+        model = Fabricio::Networking::RequestModel.new do |config|
+          config.type = :GET
+          config.base_url = FABRIC_API_URL
+          config.api_path = path
+          config.params = params
+        end
+        model
+      end
+
       # Returns a request model for obtaining the count of app crashes
       #
       # @param app_id [String]

--- a/lib/fabricio/services/app_service.rb
+++ b/lib/fabricio/services/app_service.rb
@@ -125,6 +125,21 @@ module Fabricio
         JSON.parse(response.body)['sessions']
       end
 
+      # Obtains the time in app per user
+      #
+      # @param id [String] Application identifier
+      # @param start_time [String] Timestamp of the start date
+      # @param end_time [String] Timestamp of the end date
+      # @param build [String] The version of the build. E.g. '4.0.1 (38)'
+      # @return [Array<Fabricio::Model::Point>]
+      def time_in_app_per_user(id, start_time, end_time, build)
+        request_model = @request_model_factory.time_in_app_per_user_request_model(@session, id, start_time, end_time, build)
+        response = @network_client.perform_request(request_model)
+        JSON.parse(response.body)['series'].map do |array|
+          Fabricio::Model::Point.new(array)
+        end
+      end
+
       # Obtains the number of crashes
       #
       # @param id [String] Application identifier

--- a/spec/lib/fabricio/networking/app_request_model_factory_spec.rb
+++ b/spec/lib/fabricio/networking/app_request_model_factory_spec.rb
@@ -76,6 +76,15 @@ describe 'AppRequestModelFactory' do
     expect(result.headers).not_to be_nil
   end
 
+  it 'should form time_in_app_per_user app request model' do
+    result = @factory.time_in_app_per_user_request_model(@session, '1', '1', '1', '1')
+
+    expect(result.type).to eq :GET
+    expect(result.base_url).not_to be_nil
+    expect(result.api_path).not_to be_nil
+    expect(result.headers).not_to be_nil
+  end
+
   it 'should form crashes app request model' do
     result = @factory.crash_count_request_model('1', '1', '1', ['1', '2'])
 

--- a/spec/lib/fabricio/service/app_service_spec.rb
+++ b/spec/lib/fabricio/service/app_service_spec.rb
@@ -81,6 +81,14 @@ describe 'AppService' do
     expect(result).not_to be_nil
   end
 
+  it 'should fetch time_in_app_per_user' do
+    response_file = File.new(Dir.getwd + '/spec/lib/fabricio/service/app_service_daily_active_stub_response.txt')
+    stub_request(:get, /time_in_app_per_user/).to_return(:body => response_file, :status => 200)
+
+    result = @service.time_in_app_per_user('1', '1', '1', '1')
+    expect(result).not_to be_nil
+  end
+
   it 'should fetch crashes' do
     response_file = File.new(Dir.getwd + '/spec/lib/fabricio/service/app_service_crashes_stub_response.txt')
     stub_request(:post, /graphql/).to_return(:body => response_file, :status => 200)


### PR DESCRIPTION
Adding an extra API for time in app per user which is a helpful metric.

Method: **GET**
Endpoint: 
```
/api/v2/organizations/{organization_id}/apps/{app_id}/growth_analytics/time_in_app_per_dau.json
```