### PR TITLE
Add constructor on FileParamStorage

### DIFF
--- a/lib/fabricio/authorization/file_param_storage.rb
+++ b/lib/fabricio/authorization/file_param_storage.rb
@@ -9,13 +9,16 @@ module Fabricio
   module Authorization
     # Stores default params as organization, app, etc.
     class FileParamStorage < AbstractParamStorage
+      def initialize(path = PARAM_FILE_PATH)
+        @path = path
+      end
 
       # Returns all stored variable
       #
       # @return [Hash]
       def obtain
-        return nil unless File.exist?(PARAM_FILE_PATH)
-        params = YAML.load_file(PARAM_FILE_PATH)
+        return nil unless File.exist?(@path)
+        params = YAML.load_file(@path)
         return {} unless params
         return params
       end
@@ -29,7 +32,7 @@ module Fabricio
 
       # Resets current state and deletes all saved params
       def reset
-        FileUtils.remove_file(PARAM_FILE_PATH)
+        FileUtils.remove_file(@path)
       end
 
       def organization_id
@@ -58,7 +61,7 @@ module Fabricio
 
       def save_to_file(hash)
         FileUtils.mkdir_p(FABRICIO_DIRECTORY_PATH)
-        File.open(PARAM_FILE_PATH,'w') do |f|
+        File.open(@path, 'w') do |f|
           f.write hash.to_yaml
         end
       end

--- a/spec/lib/fabricio/authorization/file_param_storage_spec.rb
+++ b/spec/lib/fabricio/authorization/file_param_storage_spec.rb
@@ -1,0 +1,29 @@
+require 'rspec'
+require 'fabricio/authorization/file_session_storage'
+require 'fabricio/authorization/file_param_storage'
+
+describe 'FileParamStorage' do
+  let(:path) { '/path/to/params.yml' }
+  let(:yaml) do
+    yaml = <<-YAML
+    organization_id: my_organization
+    app_id: my_app
+    YAML
+    YAML.load(yaml)
+  end
+
+  before(:each) do
+    allow(YAML).to receive(:load_file).with(path).and_return(yaml)
+    allow(File).to receive(:exist?).with(path).and_return(true)
+    @storage = Fabricio::Authorization::FileParamStorage.new(path)
+  end
+
+  describe '#organization_id' do
+    it { expect(@storage.organization_id).to eq('my_organization') }
+  end
+
+  describe '#app_id' do
+    it { expect(@storage.app_id).to eq('my_app') }
+  end
+end
+


### PR DESCRIPTION
Currently, path of FileParamStorage is hard coded.

So I added the constructor to set config file path and add specs.